### PR TITLE
More robust pivotal id finding

### DIFF
--- a/lib/pivotal.rb
+++ b/lib/pivotal.rb
@@ -1,13 +1,19 @@
 require "rest-client"
 
 class Pivotal
-  def self.regex_for_pivotal_id(what)
-    return false if what.nil?
+  def self.regex_for_pivotal_id_in_branch(what)
+    return nil if what.nil?
     what[/[0-9]{7,}/]
   end
 
+  def self.regex_for_pivotal_id_in_body(what)
+    return nil if what.nil?
+    captures = what[/#[0-9]{7,}/] || what[/show\/[0-9]{7,}/]
+    captures[/[0-9]{7,}/] if captures
+  end
+
   def self.find_pivotal_id(body, branch)
-    regex_for_pivotal_id(body) || regex_for_pivotal_id(branch)
+    regex_for_pivotal_id_in_body(body) || regex_for_pivotal_id_in_branch(branch)
   end
 
 

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -154,7 +154,9 @@ class TestTest < Minitest::Test
   def test_that_it_can_find_a_pivotal_url_in_a_body
     with_errors do
       assert_equal("1234567",
-        Pivotal.find_pivotal_id("Blah blah 1234567 blah blah", "branch_name_here"))
+        Pivotal.find_pivotal_id("Blah blah #1234567 blah blah", "branch_name_here"))
+      assert_equal("1234567",
+        Pivotal.find_pivotal_id("Blah blah show/1234567 blah blah", "branch_name_here"))
     end
   end
 
@@ -162,6 +164,15 @@ class TestTest < Minitest::Test
     with_errors do
       assert_equal("1234567",
          Pivotal.find_pivotal_id("Blah blah blah blah", "branch_name_here_1234567"))
+    end
+  end
+
+  def test_that_it_ignores_fake_ids_in_a_body
+    with_errors do
+      assert_equal("9876543",
+        Pivotal.find_pivotal_id("Fake id: 1234567, Real id: #9876543 blah blah", "branch_name_here"))
+      assert_equal("9876543",
+        Pivotal.find_pivotal_id("Fake id: 1234567, Real id: show/9876543 blah blah", "branch_name_here"))
     end
   end
 

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -192,7 +192,7 @@ class TestTest < Minitest::Test
   def test_that_it_finishes_an_open_pr
     opening_params = complete_pr_params.tap do |params|
       params["action"] = "opened"
-      params["pull_request"]["body"] = "1234567"  # Add a Pivotal ID
+      params["pull_request"]["body"] = "#1234567"  # Add a Pivotal ID
     end
     with_errors do
       Github.stub(:nag_for_a_pivotal_id!, MiniTest::Mock.new) do
@@ -208,7 +208,7 @@ class TestTest < Minitest::Test
   def test_that_it_finishes_an_reopened_pr
     opening_params = complete_pr_params.tap do |params|
       params["action"] = "reopened"
-      params["pull_request"]["body"] = "1234567"  # Add a Pivotal ID
+      params["pull_request"]["body"] = "#1234567"  # Add a Pivotal ID
     end
     with_errors do
       Github.stub(:nag_for_a_pivotal_id!, MiniTest::Mock.new) do


### PR DESCRIPTION
Some issue bodies had length-7 numbers as well as Pivotal IDs, which was confusing YAGPI. This forces all ids to either be links or start with `#`.

Ids in branches still function as normal.
